### PR TITLE
Use strings.Builder and strconv.Quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ func getHTTPRequestCounter(host string) *vm.Counter {
 }
 ```
 
-Vimebu also exposes a way to escape quotes on label values you don't control using `Builder.LabelAppendQuote`.
+Vimebu also exposes a way to escape quotes on label values you don't control using `Builder.LabelQuote`.
 ```go
 import (
     "github.com/wazazaby/vimebu"
@@ -65,7 +65,7 @@ import (
 func getHTTPRequestCounter(path string) *vm.Counter {
     metric := vimebu.
         Metric("api_http_requests_total").
-        LabelAppendQuote("path", path).
+        LabelQuote("path", path).
         String() // api_http_requests_total{path="some/bro\"ken/path"}
     return vm.GetOrCreateCounter(metric)
 }

--- a/vimebu.go
+++ b/vimebu.go
@@ -1,7 +1,6 @@
 package vimebu
 
 import (
-	"bytes"
 	"strconv"
 	"strings"
 )
@@ -23,7 +22,7 @@ const (
 //
 // The zero value is ready to use.
 type Builder struct {
-	underlying      bytes.Buffer
+	underlying      strings.Builder
 	flName, flLabel bool
 }
 
@@ -102,9 +101,7 @@ func (b *Builder) label(name, value string, appendQuote bool) *Builder {
 	b.underlying.WriteString(name)
 	b.underlying.WriteByte(equalByte)
 	if appendQuote { // If we need to escape quotes in the label value.
-		buf := b.underlying.AvailableBuffer()
-		quoted := strconv.AppendQuote(buf, value) // Append directly to a buffer with b.underlying.Available() cap as it's the fastest option available.
-		b.underlying.Write(quoted)
+		b.underlying.WriteString(strconv.Quote(value))
 	} else { // Otherwise, just wrap the label value inside a pair of double quotes.
 		b.underlying.WriteByte(doubleQuotesByte)
 		b.underlying.WriteString(value)

--- a/vimebu.go
+++ b/vimebu.go
@@ -57,29 +57,29 @@ func (b *Builder) Metric(name string) *Builder {
 	return b
 }
 
-// LabelAppendQuote appends a pair of label name and label value to the Builder. Quotes inside the label value will be escaped.
+// LabelQuote appends a pair of label name and label value to the Builder. Quotes inside the label value will be escaped.
 //
 // Panics if the label name or label value contains more than [vimebu.LabelNameMaxLen] or [vimebu.LabelValueMaxLen] bytes respectively.
 //
 // NoOp if the label name or label value are empty.
-func (b *Builder) LabelAppendQuote(name, value string) *Builder {
-	appendQuote := true
-	return b.label(name, value, appendQuote)
+func (b *Builder) LabelQuote(name, value string) *Builder {
+	escapeQuote := true
+	return b.label(name, value, escapeQuote)
 }
 
 // Label appends a pair of label name and label value to the Builder.
-// Unlike [vimebu.Builder.LabelAppendQuote], quotes inside the label value will not be escaped.
+// Unlike [vimebu.Builder.LabelQuote], quotes inside the label value will not be escaped.
 // It's better suited for a label value where you control the input (either it is already sanitized, or it comes from a const or an enum for example).
 //
 // Panics if the label name or label value contains more than [vimebu.LabelNameMaxLen] or [vimebu.LabelValueMaxLen] bytes respectively.
 //
 // NoOp if the label name or label value are empty.
 func (b *Builder) Label(name, value string) *Builder {
-	appendQuote := false
-	return b.label(name, value, appendQuote)
+	escapeQuote := false
+	return b.label(name, value, escapeQuote)
 }
 
-func (b *Builder) label(name, value string, appendQuote bool) *Builder {
+func (b *Builder) label(name, value string, escapeQuote bool) *Builder {
 	if !b.flName || name == "" || value == "" {
 		return b
 	}
@@ -100,7 +100,7 @@ func (b *Builder) label(name, value string, appendQuote bool) *Builder {
 
 	b.underlying.WriteString(name)
 	b.underlying.WriteByte(equalByte)
-	if appendQuote { // If we need to escape quotes in the label value.
+	if escapeQuote { // If we need to escape quotes in the label value.
 		b.underlying.WriteString(strconv.Quote(value))
 	} else { // Otherwise, just wrap the label value inside a pair of double quotes.
 		b.underlying.WriteByte(doubleQuotesByte)

--- a/vimebu.go
+++ b/vimebu.go
@@ -17,8 +17,8 @@ const (
 	doubleQuotesByte = byte('"')
 )
 
-// Builder is used to efficiently build a VictoriaMetrics or Prometheus metric.
-// It's backed by a bytes.Buffer to minimize memory copying.
+// Builder is used to efficiently build a VictoriaMetrics metric.
+// It's backed by a strings.Builder to minimize memory copying.
 //
 // The zero value is ready to use.
 type Builder struct {
@@ -130,7 +130,7 @@ func (b *Builder) Reset() {
 //
 // It can be useful is you already know the size of your metric, including labels.
 //
-// Please see [bytes.Buffer.Grow].
+// Please see [strings.Builder.Grow].
 func (b *Builder) Grow(n int) *Builder {
 	b.underlying.Grow(n)
 	return b

--- a/vimebu_test.go
+++ b/vimebu_test.go
@@ -78,7 +78,7 @@ func TestBuilder(t *testing.T) {
 			b.Metric(tc.input.name)
 			for _, label := range tc.input.labels {
 				if strings.Contains(label.value, `"`) {
-					b.LabelAppendQuote(label.name, label.value)
+					b.LabelQuote(label.name, label.value)
 				} else {
 					b.Label(label.name, label.value)
 				}
@@ -107,7 +107,7 @@ func BenchmarkBuilder(b *testing.B) {
 		var builder Builder
 		_ = builder.Metric("http_request_duration_seconds").
 			Label("status", status).
-			LabelAppendQuote("path", path).
+			LabelQuote("path", path).
 			Label("host", host).
 			Label("cluster", cluster).
 			String()
@@ -131,10 +131,10 @@ func BenchmarkBuilderAppendQuoteOnly(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		var builder Builder
 		_ = builder.Metric("http_request_duration_seconds").
-			LabelAppendQuote("status", status).
-			LabelAppendQuote("path", path).
-			LabelAppendQuote("host", host).
-			LabelAppendQuote("cluster", cluster).
+			LabelQuote("status", status).
+			LabelQuote("path", path).
+			LabelQuote("host", host).
+			LabelQuote("cluster", cluster).
 			String()
 	}
 }

--- a/vimebu_test.go
+++ b/vimebu_test.go
@@ -104,7 +104,8 @@ var (
 
 func BenchmarkBuilder(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		_ = Metric("http_request_duration_seconds").
+		var builder Builder
+		_ = builder.Metric("http_request_duration_seconds").
 			Label("status", status).
 			LabelAppendQuote("path", path).
 			Label("host", host).
@@ -116,7 +117,8 @@ func BenchmarkBuilder(b *testing.B) {
 func BenchmarkBuilderAppendQuoteNone(b *testing.B) {
 	pathSafe := strconv.Quote(path)
 	for n := 0; n < b.N; n++ {
-		_ = Metric("http_request_duration_seconds").
+		var builder Builder
+		_ = builder.Metric("http_request_duration_seconds").
 			Label("status", status).
 			Label("path", pathSafe).
 			Label("host", host).
@@ -127,7 +129,8 @@ func BenchmarkBuilderAppendQuoteNone(b *testing.B) {
 
 func BenchmarkBuilderAppendQuoteOnly(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		_ = Metric("http_request_duration_seconds").
+		var builder Builder
+		_ = builder.Metric("http_request_duration_seconds").
 			LabelAppendQuote("status", status).
 			LabelAppendQuote("path", path).
 			LabelAppendQuote("host", host).

--- a/vimebu_test.go
+++ b/vimebu_test.go
@@ -141,54 +141,54 @@ func BenchmarkBuilderAppendQuoteOnly(b *testing.B) {
 
 func BenchmarkStringsBuilder(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		var b strings.Builder
-		b.WriteString(`http_request_duration_seconds{status="`)
-		b.WriteString(status)
-		b.WriteString(`",path=`)
-		b.WriteString(strconv.Quote(path))
-		b.WriteString(`,host="`)
-		b.WriteString(host)
-		b.WriteString(`",cluster="`)
-		b.WriteString(cluster)
-		b.WriteString(`"}`)
-		_ = b.String()
+		var builder strings.Builder
+		builder.WriteString(`http_request_duration_seconds{status="`)
+		builder.WriteString(status)
+		builder.WriteString(`",path=`)
+		builder.WriteString(strconv.Quote(path))
+		builder.WriteString(`,host="`)
+		builder.WriteString(host)
+		builder.WriteString(`",cluster="`)
+		builder.WriteString(cluster)
+		builder.WriteString(`"}`)
+		_ = builder.String()
 	}
 }
 
 func BenchmarkBytesBuffer(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		var b bytes.Buffer
-		b.WriteString(`http_request_duration_seconds{status="`)
-		b.WriteString(status)
-		b.WriteString(`",path=`)
-		b.WriteString(strconv.Quote(path))
-		b.WriteString(`,host="`)
-		b.WriteString(host)
-		b.WriteString(`",cluster="`)
-		b.WriteString(cluster)
-		b.WriteString(`"}`)
-		_ = b.String()
+		var builder bytes.Buffer
+		builder.WriteString(`http_request_duration_seconds{status="`)
+		builder.WriteString(status)
+		builder.WriteString(`",path=`)
+		builder.WriteString(strconv.Quote(path))
+		builder.WriteString(`,host="`)
+		builder.WriteString(host)
+		builder.WriteString(`",cluster="`)
+		builder.WriteString(cluster)
+		builder.WriteString(`"}`)
+		_ = builder.String()
 	}
 }
 
 func BenchmarkBytesBufferFastQuote(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		var b bytes.Buffer
-		b.WriteString(`http_request_duration_seconds{status="`)
-		b.WriteString(status)
-		b.WriteString(`",path=`)
+		var builder bytes.Buffer
+		builder.WriteString(`http_request_duration_seconds{status="`)
+		builder.WriteString(status)
+		builder.WriteString(`",path=`)
 
-		buf := b.AvailableBuffer()
+		buf := builder.AvailableBuffer()
 		quoted := strconv.AppendQuote(buf, path)
-		b.Write(quoted)
+		builder.Write(quoted)
 
-		b.WriteString(`,host="`)
-		b.WriteString(host)
-		b.WriteString(`",cluster="`)
-		b.WriteString(cluster)
-		b.WriteString(`"}`)
+		builder.WriteString(`,host="`)
+		builder.WriteString(host)
+		builder.WriteString(`",cluster="`)
+		builder.WriteString(cluster)
+		builder.WriteString(`"}`)
 
-		_ = b.String()
+		_ = builder.String()
 	}
 }
 


### PR DESCRIPTION
At first, I thought that using `bytes.Buffer` + `strconv.AppendQuote` was faster than using `strings.Builder` + `strconv.Quote`, but after some benchmarking it turns out it's not the case. Here are some samples.

<details>
<summary>Using bytes.Buffer</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/wazazaby/vimebu
BenchmarkBuilder-10                   	 3414580	       338.0 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilder-10                   	 3540535	       339.2 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilder-10                   	 3522084	       345.2 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilder-10                   	 3340707	       350.1 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilder-10                   	 3545394	       337.7 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilder-10                   	 3552984	       338.9 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilder-10                   	 3550158	       349.3 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilder-10                   	 3544591	       339.0 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilder-10                   	 3552189	       346.2 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilder-10                   	 3537568	       340.9 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	 8593497	       142.8 ns/op	     320 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	 8372839	       139.8 ns/op	     320 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	 8690164	       143.2 ns/op	     320 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	 8790312	       138.8 ns/op	     320 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	 8814727	       145.3 ns/op	     320 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	 8683002	       139.1 ns/op	     320 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	 8632513	       137.0 ns/op	     320 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	 8700102	       137.3 ns/op	     320 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	 8453677	       142.9 ns/op	     320 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	 8058141	       141.8 ns/op	     320 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2281246	       536.1 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2235252	       529.9 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2266074	       537.5 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2079572	       546.3 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2272840	       523.4 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2296305	       517.3 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2266734	       528.8 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2303331	       513.5 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2317713	       518.1 ns/op	     416 B/op	       5 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2313747	       508.2 ns/op	     416 B/op	       5 allocs/op
PASS
ok  	github.com/wazazaby/vimebu	92.885s
```
</details>

<details>
<summary>Using strings.Builder</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/wazazaby/vimebu
BenchmarkBuilder-10                   	 3936693	       289.7 ns/op	     272 B/op	       4 allocs/op
BenchmarkBuilder-10                   	 4173040	       290.9 ns/op	     272 B/op	       4 allocs/op
BenchmarkBuilder-10                   	 4153046	       289.5 ns/op	     272 B/op	       4 allocs/op
BenchmarkBuilder-10                   	 4162498	       289.7 ns/op	     272 B/op	       4 allocs/op
BenchmarkBuilder-10                   	 4099214	       289.8 ns/op	     272 B/op	       4 allocs/op
BenchmarkBuilder-10                   	 3807670	       293.9 ns/op	     272 B/op	       4 allocs/op
BenchmarkBuilder-10                   	 4130784	       292.3 ns/op	     272 B/op	       4 allocs/op
BenchmarkBuilder-10                   	 4075612	       290.0 ns/op	     272 B/op	       4 allocs/op
BenchmarkBuilder-10                   	 4167272	       293.4 ns/op	     272 B/op	       4 allocs/op
BenchmarkBuilder-10                   	 4147341	       289.4 ns/op	     272 B/op	       4 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	11363053	       105.4 ns/op	     224 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	11381712	       105.7 ns/op	     224 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	11299815	       105.4 ns/op	     224 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	11400986	       105.2 ns/op	     224 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	11421717	       106.0 ns/op	     224 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	11333067	       105.3 ns/op	     224 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	11269770	       106.0 ns/op	     224 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	11386022	       106.2 ns/op	     224 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	11489625	       105.6 ns/op	     224 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteNone-10    	11416881	       105.6 ns/op	     224 B/op	       3 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2322031	       517.3 ns/op	     312 B/op	       7 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2321367	       518.2 ns/op	     312 B/op	       7 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2313603	       517.6 ns/op	     312 B/op	       7 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2324313	       516.8 ns/op	     312 B/op	       7 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2323504	       518.4 ns/op	     312 B/op	       7 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2313649	       531.0 ns/op	     312 B/op	       7 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2303410	       526.9 ns/op	     312 B/op	       7 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2311272	       517.1 ns/op	     312 B/op	       7 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2283028	       528.0 ns/op	     312 B/op	       7 allocs/op
BenchmarkBuilderAppendQuoteOnly-10    	 2290184	       847.7 ns/op	     312 B/op	       7 allocs/op
PASS
ok  	github.com/wazazaby/vimebu	92.718s
```
</details>

Comparing the two with `benchstat` gives me this result :
```
goos: darwin
goarch: arm64
pkg: github.com/wazazaby/vimebu
                          │ bytes.buffer.txt │         strings.builder.txt         │
                          │      sec/op      │   sec/op     vs base                │
Builder-10                       341.6n ± 1%   289.8n ± 0%  -15.16% (p=0.000 n=20)
BuilderAppendQuoteNone-10        139.5n ± 2%   105.7n ± 0%  -24.27% (p=0.000 n=20)
BuilderAppendQuoteOnly-10        517.6n ± 2%   522.0n ± 1%        ~ (p=0.086 n=20)
geomean                          291.1n        251.9n       -13.47%

                          │ bytes.buffer.txt │        strings.builder.txt         │
                          │       B/op       │    B/op     vs base                │
Builder-10                        416.0 ± 0%   272.0 ± 0%  -34.62% (p=0.000 n=20)
BuilderAppendQuoteNone-10         320.0 ± 0%   224.0 ± 0%  -30.00% (p=0.000 n=20)
BuilderAppendQuoteOnly-10         416.0 ± 0%   312.0 ± 0%  -25.00% (p=0.000 n=20)
geomean                           381.2        266.9       -29.98%

                          │ bytes.buffer.txt │         strings.builder.txt          │
                          │    allocs/op     │ allocs/op   vs base                  │
Builder-10                        5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=20)
BuilderAppendQuoteNone-10         3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=20) ¹
BuilderAppendQuoteOnly-10         5.000 ± 0%   7.000 ± 0%  +40.00% (p=0.000 n=20)
geomean                           4.217        4.380        +3.85%
¹ all samples are equal
```

As you can see, using `strings.Builder` is about ~13% faster and it allocates about ~30% less bytes. The only downside is that is makes 2 more allocations per operation when every label value needs to be quoted.