### PR TITLE
ensure value contains a double quote before escaping

### DIFF
--- a/vimebu.go
+++ b/vimebu.go
@@ -100,7 +100,7 @@ func (b *Builder) label(name, value string, escapeQuote bool) *Builder {
 
 	b.underlying.WriteString(name)
 	b.underlying.WriteByte(equalByte)
-	if escapeQuote { // If we need to escape quotes in the label value.
+	if escapeQuote && strings.Contains(value, `"`) { // If we need to escape quotes in the label value.
 		b.underlying.WriteString(strconv.Quote(value))
 	} else { // Otherwise, just wrap the label value inside a pair of double quotes.
 		b.underlying.WriteByte(doubleQuotesByte)


### PR DESCRIPTION
In most cases, it's more expensive to call `strconv.Quote` on a value that doesn't contain a double quote, than checking if the value actually contains one.