### PR TITLE
create functional builder

### DIFF
--- a/buffer_pool.go
+++ b/buffer_pool.go
@@ -1,0 +1,27 @@
+package vimebu
+
+import (
+	"bytes"
+	"sync"
+)
+
+// bytesBufferPool is a simple pool to create or retrieve a [bytes.Buffer].
+var bytesBufferPool = sync.Pool{
+	New: func() any {
+		return new(bytes.Buffer)
+	},
+}
+
+// getBuffer acquires a [bytes.Buffer] from the pool.
+func getBuffer() *bytes.Buffer {
+	return bytesBufferPool.Get().(*bytes.Buffer)
+}
+
+// putBuffer resets and returns a [bytes.Buffer] to the pool.
+func putBuffer(b *bytes.Buffer) {
+	if b == nil {
+		return
+	}
+	b.Reset()
+	bytesBufferPool.Put(b)
+}

--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,13 @@
+package vimebu
+
+const (
+	MetricNameMaxLen = 256  // MetricNameMaxLen is the maximum len in bytes allowed for the metric name.
+	LabelNameMaxLen  = 128  // LabelNameMaxLen is the maximum len in bytes allowed for a label name.
+	LabelValueLen    = 1024 // LabelValueLen is the maximum len in bytes allowed for a label value.
+
+	leftBracketByte  = byte('{')
+	rightBracketByte = byte('}')
+	commaByte        = byte(',')
+	equalByte        = byte('=')
+	doubleQuotesByte = byte('"')
+)

--- a/vimebu.go
+++ b/vimebu.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"strconv"
 	"strings"
-	"sync"
 )
 
 const (
@@ -18,27 +17,6 @@ const (
 	equalByte        = byte('=')
 	doubleQuotesByte = byte('"')
 )
-
-// bytesBufferPool is a simple pool to create or retrieve a [bytes.Buffer].
-var bytesBufferPool = sync.Pool{
-	New: func() any {
-		return new(bytes.Buffer)
-	},
-}
-
-// getBuffer acquires a [bytes.Buffer] from the pool.
-func getBuffer() *bytes.Buffer {
-	return bytesBufferPool.Get().(*bytes.Buffer)
-}
-
-// putBuffer resets and returns a [bytes.Buffer] to the pool.
-func putBuffer(b *bytes.Buffer) {
-	if b == nil {
-		return
-	}
-	b.Reset()
-	bytesBufferPool.Put(b)
-}
 
 // Builder is used to efficiently build a VictoriaMetrics metric.
 // It's backed by a bytes.Buffer to minimize memory copying.

--- a/vimebu.go
+++ b/vimebu.go
@@ -61,7 +61,7 @@ func (b *Builder) Metric(name string) *Builder {
 
 // LabelQuote appends a pair of label name and label value to the Builder. Quotes inside the label value will be escaped.
 //
-// Panics if the label name or label value contains more than [vimebu.LabelNameMaxLen] or [vimebu.LabelValueMaxLen] bytes respectively.
+// Panics if the label name or label value contain more than [vimebu.LabelNameMaxLen] or [vimebu.LabelValueMaxLen] bytes respectively.
 //
 // NoOp if the label name or label value are empty.
 func (b *Builder) LabelQuote(name, value string) *Builder {
@@ -72,7 +72,7 @@ func (b *Builder) LabelQuote(name, value string) *Builder {
 // Unlike [vimebu.Builder.LabelQuote], quotes inside the label value will not be escaped.
 // It's better suited for a label value where you control the input (either it is already sanitized, or it comes from a const or an enum for example).
 //
-// Panics if the label name or label value contains more than [vimebu.LabelNameMaxLen] or [vimebu.LabelValueMaxLen] bytes respectively.
+// Panics if the label name or label value contain more than [vimebu.LabelNameMaxLen] or [vimebu.LabelValueMaxLen] bytes respectively.
 //
 // NoOp if the label name or label value are empty.
 func (b *Builder) Label(name, value string) *Builder {

--- a/vimebu.go
+++ b/vimebu.go
@@ -6,18 +6,6 @@ import (
 	"strings"
 )
 
-const (
-	MetricNameMaxLen = 256  // MetricNameMaxLen is the maximum len in bytes allowed for the metric name.
-	LabelNameMaxLen  = 128  // LabelNameMaxLen is the maximum len in bytes allowed for a label name.
-	LabelValueLen    = 1024 // LabelValueLen is the maximum len in bytes allowed for a label value.
-
-	leftBracketByte  = byte('{')
-	rightBracketByte = byte('}')
-	commaByte        = byte(',')
-	equalByte        = byte('=')
-	doubleQuotesByte = byte('"')
-)
-
 // Builder is used to efficiently build a VictoriaMetrics metric.
 // It's backed by a bytes.Buffer to minimize memory copying.
 //

--- a/vimebu.go
+++ b/vimebu.go
@@ -29,7 +29,7 @@ func Metric(name string) *Builder {
 
 // Metric sets the metric name of the Builder.
 //
-// NoOp if called more than once for the same builder or if the name is empty.
+// NoOp if called more than once for the same builder.
 //
 // Panics if the name is empty, contains more than [vimebu.MetricNameMaxLen] bytes or if it contains a double quote.
 func (b *Builder) Metric(name string) *Builder {

--- a/vimebu_func.go
+++ b/vimebu_func.go
@@ -1,0 +1,115 @@
+package vimebu
+
+import (
+	"strconv"
+	"strings"
+)
+
+// LabelCallback TODO:
+type LabelCallback func() (name, value string, escapeQuote bool)
+
+// WithLabel TODO:
+func WithLabel(name, value string) LabelCallback {
+	if len(name) > LabelNameMaxLen {
+		panic("label name contains too many bytes")
+	}
+
+	if len(value) > LabelValueLen {
+		panic("label value contains too many bytes")
+	}
+
+	return func() (string, string, bool) {
+		return name, value, false
+	}
+}
+
+// WithLabelCond TODO:
+func WithLabelCond(fn func() bool, name, value string) LabelCallback {
+	if fn() {
+		return WithLabel(name, value)
+	}
+	return WithLabel("", "")
+}
+
+// WithLabelQuote TODO:
+func WithLabelQuote(name, value string) LabelCallback {
+	if len(name) > LabelNameMaxLen {
+		panic("label name contains too many bytes")
+	}
+
+	if len(value) > LabelValueLen {
+		panic("label value contains too many bytes")
+	}
+
+	return func() (string, string, bool) {
+		return name, value, true
+	}
+}
+
+// WithLabelQuoteCond TODO:
+func WithLabelQuoteCond(fn func() bool, name, value string) LabelCallback {
+	if fn() {
+		return WithLabelQuote(name, value)
+	}
+	return WithLabelQuote("", "")
+}
+
+// BuilderFunc is used to efficiently build a VictoriaMetrics metric.
+func BuilderFunc(name string, labels ...LabelCallback) string {
+	ln := len(name)
+	if ln == 0 {
+		panic("metric name must not be empty")
+	}
+
+	if ln > MetricNameMaxLen {
+		panic("metric name contains too many bytes")
+	}
+
+	if strings.Contains(name, `"`) {
+		panic("metric name should not contain double quotes")
+	}
+
+	// In case there are no labels, using a strings.Builder is actually
+	// about ~9% faster than concatenating the name and brackets.
+	if len(labels) == 0 {
+		var b strings.Builder
+		b.Grow(ln + 2)
+		b.WriteString(name)
+		b.WriteString("{}")
+		return b.String()
+	}
+
+	b := getBuffer()
+	defer putBuffer(b)
+
+	b.WriteString(name)
+	b.WriteByte(leftBracketByte)
+	var flLabel bool
+	for _, callback := range labels {
+		name, value, escapeQuote := callback()
+		if name == "" || value == "" {
+			continue
+		}
+
+		if flLabel {
+			b.WriteByte(commaByte)
+		} else {
+			flLabel = true
+		}
+
+		b.WriteString(name)
+		b.WriteByte(equalByte)
+		if escapeQuote && strings.Contains(value, `"`) {
+			buf := b.AvailableBuffer()
+			quoted := strconv.AppendQuote(buf, value)
+			b.Write(quoted)
+		} else {
+			b.WriteByte(doubleQuotesByte)
+			b.WriteString(value)
+			b.WriteByte(doubleQuotesByte)
+		}
+	}
+
+	b.WriteByte(rightBracketByte)
+	return b.String()
+}

--- a/vimebu_func_test.go
+++ b/vimebu_func_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func handleTestCaseFn(t *testing.T, tc testCase) {
+func handleTestCaseFunc(t *testing.T, tc testCase) {
 	labels := make([]LabelCallback, 0, len(tc.input.labels))
 
 	for _, label := range tc.input.labels {
@@ -21,16 +21,16 @@ func handleTestCaseFn(t *testing.T, tc testCase) {
 	require.Equal(t, tc.expected, result)
 }
 
-func TestBuilderFn(t *testing.T) {
+func TestBuilderFunc(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.mustPanic {
 				require.Panics(t, func() {
-					handleTestCaseFn(t, tc)
+					handleTestCaseFunc(t, tc)
 				})
 			} else {
 				require.NotPanics(t, func() {
-					handleTestCaseFn(t, tc)
+					handleTestCaseFunc(t, tc)
 				})
 			}
 		})
@@ -47,7 +47,7 @@ func TestLabelCond(t *testing.T) {
 	require.Equal(t, `test_cond{should="appear",present="/and/\"quoted\""}`, result)
 }
 
-func BenchmarkBuilderFnTestCases(b *testing.B) {
+func BenchmarkBuilderFuncTestCases(b *testing.B) {
 	for _, tc := range testCases {
 		if tc.mustPanic { // Skip test cases that panics as they will break the benchmarks.
 			continue

--- a/vimebu_func_test.go
+++ b/vimebu_func_test.go
@@ -1,0 +1,71 @@
+package vimebu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func handleTestCaseFn(t *testing.T, tc testCase) {
+	labels := make([]LabelCallback, 0, len(tc.input.labels))
+
+	for _, label := range tc.input.labels {
+		if label.shouldQuote {
+			labels = append(labels, WithLabelQuote(label.name, label.value))
+		} else {
+			labels = append(labels, WithLabel(label.name, label.value))
+		}
+	}
+
+	result := BuilderFunc(tc.input.name, labels...)
+	require.Equal(t, tc.expected, result)
+}
+
+func TestBuilderFn(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.mustPanic {
+				require.Panics(t, func() {
+					handleTestCaseFn(t, tc)
+				})
+			} else {
+				require.NotPanics(t, func() {
+					handleTestCaseFn(t, tc)
+				})
+			}
+		})
+	}
+}
+
+func TestLabelCond(t *testing.T) {
+	result := BuilderFunc("test_cond",
+		WithLabelCond(func() bool { return true }, "should", "appear"),
+		WithLabelCond(func() bool { return false }, "should", "not"),
+		WithLabelQuoteCond(func() bool { return true }, "present", `/and/"quoted"`),
+		WithLabelQuoteCond(func() bool { return false }, "absent", `/and/"quoted"`),
+	)
+	require.Equal(t, `test_cond{should="appear",present="/and/\"quoted\""}`, result)
+}
+
+func BenchmarkBuilderFnTestCases(b *testing.B) {
+	for _, tc := range testCases {
+		if tc.mustPanic { // Skip test cases that panics as they will break the benchmarks.
+			continue
+		}
+		b.Run(tc.name, func(b *testing.B) {
+			labels := make([]LabelCallback, 0, len(tc.input.labels))
+
+			for _, label := range tc.input.labels {
+				if label.shouldQuote {
+					labels = append(labels, WithLabelQuote(label.name, label.value))
+				} else {
+					labels = append(labels, WithLabel(label.name, label.value))
+				}
+			}
+
+			for n := 0; n < b.N; n++ {
+				_ = BuilderFunc(tc.input.name, labels...)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`benchstat` results against the standard "builder pattern" builder.
```
goos: darwin
goarch: arm64
pkg: github.com/wazazaby/vimebu
                                                          │ builder.txt │              func.txt               │
                                                          │   sec/op    │   sec/op     vs base                │
BuilderTestCases/metric_with_labels-10                      68.60n ± 0%   64.37n ± 3%   -6.17% (p=0.000 n=15)
BuilderTestCases/metric_with_single_label-10                49.33n ± 0%   46.44n ± 0%   -5.86% (p=0.000 n=15)
BuilderTestCases/metric_without_label-10                    34.98n ± 0%   22.19n ± 0%  -36.56% (p=0.000 n=15)
BuilderTestCases/some_empty_labels_and_values-10            57.57n ± 1%   51.93n ± 0%   -9.80% (p=0.000 n=15)
BuilderTestCases/values_contain_double_quotes-10            473.9n ± 1%   470.7n ± 1%        ~ (p=0.076 n=15)
BuilderTestCases/values_with_and_without_double_quotes-10   509.1n ± 1%   504.0n ± 1%   -1.00% (p=0.001 n=15)
geomean                                                     108.6n        96.69n       -11.00%

                                                          │ builder.txt │              func.txt               │
                                                          │    B/op     │    B/op     vs base                 │
BuilderTestCases/metric_with_labels-10                       64.00 ± 0%   64.00 ± 0%       ~ (p=1.000 n=15) ¹
BuilderTestCases/metric_with_single_label-10                 32.00 ± 0%   32.00 ± 0%       ~ (p=1.000 n=15) ¹
BuilderTestCases/metric_without_label-10                     32.00 ± 0%   32.00 ± 0%       ~ (p=1.000 n=15) ¹
BuilderTestCases/some_empty_labels_and_values-10             48.00 ± 0%   48.00 ± 0%       ~ (p=1.000 n=15) ¹
BuilderTestCases/values_contain_double_quotes-10             112.0 ± 0%   112.0 ± 0%       ~ (p=1.000 n=15) ¹
BuilderTestCases/values_with_and_without_double_quotes-10    160.0 ± 0%   160.0 ± 0%       ~ (p=1.000 n=15) ¹
geomean                                                      61.92        61.92       +0.00%
¹ all samples are equal

                                                          │ builder.txt │              func.txt               │
                                                          │  allocs/op  │ allocs/op   vs base                 │
BuilderTestCases/metric_with_labels-10                       1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=15) ¹
BuilderTestCases/metric_with_single_label-10                 1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=15) ¹
BuilderTestCases/metric_without_label-10                     1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=15) ¹
BuilderTestCases/some_empty_labels_and_values-10             1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=15) ¹
BuilderTestCases/values_contain_double_quotes-10             1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=15) ¹
BuilderTestCases/values_with_and_without_double_quotes-10    1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=15) ¹
geomean                                                      1.000        1.000       +0.00%
¹ all samples are equal
```