### PR TITLE
use sync.Pool to retrieve bytes.Buffers

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wazazaby/vimebu
 
-go 1.20
+go 1.21
 
 require github.com/stretchr/testify v1.8.4
 

--- a/vimebu.go
+++ b/vimebu.go
@@ -1,8 +1,10 @@
 package vimebu
 
 import (
+	"bytes"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 const (
@@ -17,13 +19,40 @@ const (
 	doubleQuotesByte = byte('"')
 )
 
+// bytesBufferPool is a simple pool to create or retrieve a [bytes.Buffer].
+var bytesBufferPool = sync.Pool{
+	New: func() any {
+		return new(bytes.Buffer)
+	},
+}
+
+// getBuffer acquires a [bytes.Buffer] from the pool.
+func getBuffer() *bytes.Buffer {
+	return bytesBufferPool.Get().(*bytes.Buffer)
+}
+
+// putBuffer resets and returns a [bytes.Buffer] to the pool.
+func putBuffer(b *bytes.Buffer) {
+	if b == nil {
+		return
+	}
+	b.Reset()
+	bytesBufferPool.Put(b)
+}
+
 // Builder is used to efficiently build a VictoriaMetrics metric.
-// It's backed by a strings.Builder to minimize memory copying.
+// It's backed by a bytes.Buffer to minimize memory copying.
 //
 // The zero value is ready to use.
 type Builder struct {
-	underlying      strings.Builder
+	underlying      *bytes.Buffer
 	flName, flLabel bool
+}
+
+func (b *Builder) init() {
+	if b.underlying == nil {
+		b.underlying = getBuffer()
+	}
 }
 
 // Metric creates a new Builder.
@@ -50,6 +79,8 @@ func (b *Builder) Metric(name string) *Builder {
 		panic("metric name should not contain double quotes")
 	}
 
+	b.init()
+
 	b.underlying.WriteString(name)
 	b.underlying.WriteByte(leftBracketByte)
 	b.flName = true
@@ -63,8 +94,7 @@ func (b *Builder) Metric(name string) *Builder {
 //
 // NoOp if the label name or label value are empty.
 func (b *Builder) LabelQuote(name, value string) *Builder {
-	escapeQuote := true
-	return b.label(name, value, escapeQuote)
+	return b.label(name, value, true)
 }
 
 // Label appends a pair of label name and label value to the Builder.
@@ -75,8 +105,7 @@ func (b *Builder) LabelQuote(name, value string) *Builder {
 //
 // NoOp if the label name or label value are empty.
 func (b *Builder) Label(name, value string) *Builder {
-	escapeQuote := false
-	return b.label(name, value, escapeQuote)
+	return b.label(name, value, false)
 }
 
 func (b *Builder) label(name, value string, escapeQuote bool) *Builder {
@@ -101,7 +130,9 @@ func (b *Builder) label(name, value string, escapeQuote bool) *Builder {
 	b.underlying.WriteString(name)
 	b.underlying.WriteByte(equalByte)
 	if escapeQuote && strings.Contains(value, `"`) { // If we need to escape quotes in the label value.
-		b.underlying.WriteString(strconv.Quote(value))
+		buf := b.underlying.AvailableBuffer()
+		quoted := strconv.AppendQuote(buf, value)
+		b.underlying.Write(quoted)
 	} else { // Otherwise, just wrap the label value inside a pair of double quotes.
 		b.underlying.WriteByte(doubleQuotesByte)
 		b.underlying.WriteString(value)
@@ -113,9 +144,11 @@ func (b *Builder) label(name, value string, escapeQuote bool) *Builder {
 
 // String builds the metric by returning the accumulated string.
 func (b *Builder) String() string {
+	defer putBuffer(b.underlying)
 	if !b.flName {
 		return ""
 	}
+
 	b.underlying.WriteByte(rightBracketByte)
 	return b.underlying.String()
 }
@@ -123,15 +156,16 @@ func (b *Builder) String() string {
 // Reset resets the Builder to be empty.
 func (b *Builder) Reset() {
 	b.flName, b.flLabel = false, false
-	b.underlying.Reset()
+	putBuffer(b.underlying)
 }
 
 // Grow exposes the underlying buffer's Grow method for preallocation purposes.
 //
 // It can be useful is you already know the size of your metric, including labels.
 //
-// Please see [strings.Builder.Grow].
+// Please see [bytes.Buffer.Grow].
 func (b *Builder) Grow(n int) *Builder {
+	b.init()
 	b.underlying.Grow(n)
 	return b
 }

--- a/vimebu_test.go
+++ b/vimebu_test.go
@@ -109,7 +109,7 @@ func handleTestCase(t *testing.T, tc testCase) {
 	var b Builder
 
 	b.Grow(128)
-	require.Equal(t, 128, b.underlying.Cap())
+	require.GreaterOrEqual(t, b.underlying.Cap(), 128)
 
 	b.Metric(tc.input.name)
 


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/wazazaby/vimebu
                                                          │   std.txt   │               pool.txt               │
                                                          │   sec/op    │   sec/op     vs base                 │
BuilderTestCases/metric_with_labels-10                      86.20n ± 1%   67.20n ± 1%   -22.03% (p=0.000 n=10)
BuilderTestCases/metric_with_single_label-10                54.06n ± 1%   48.38n ± 3%   -10.52% (p=0.000 n=10)
BuilderTestCases/metric_without_label-10                    25.23n ± 2%   34.35n ± 1%   +36.15% (p=0.000 n=10)
BuilderTestCases/no_name-10                                 2.066n ± 3%   4.625n ± 1%  +123.89% (p=0.000 n=10)
BuilderTestCases/some_empty_labels_and_values-10            62.45n ± 1%   57.93n ± 0%    -7.23% (p=0.000 n=10)
BuilderTestCases/values_contain_double_quotes-10            581.2n ± 1%   472.9n ± 0%   -18.64% (p=0.000 n=10)
BuilderTestCases/values_with_and_without_double_quotes-10   604.2n ± 2%   506.5n ± 0%   -16.18% (p=0.000 n=10)
geomean                                                     65.77n        68.62n         +4.33%

                                                          │    std.txt    │               pool.txt               │
                                                          │     B/op      │    B/op     vs base                  │
BuilderTestCases/metric_with_labels-10                      168.00 ± 0%     64.00 ± 0%  -61.90% (p=0.000 n=10)
BuilderTestCases/metric_with_single_label-10                 72.00 ± 0%     32.00 ± 0%  -55.56% (p=0.000 n=10)
BuilderTestCases/metric_without_label-10                     32.00 ± 0%     32.00 ± 0%        ~ (p=1.000 n=10) ¹
BuilderTestCases/no_name-10                                  0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
BuilderTestCases/some_empty_labels_and_values-10             72.00 ± 0%     48.00 ± 0%  -33.33% (p=0.000 n=10)
BuilderTestCases/values_contain_double_quotes-10             504.0 ± 0%     112.0 ± 0%  -77.78% (p=0.000 n=10)
BuilderTestCases/values_with_and_without_double_quotes-10    504.0 ± 0%     160.0 ± 0%  -68.25% (p=0.000 n=10)
geomean                                                                 ²               -49.86%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                          │   std.txt    │               pool.txt               │
                                                          │  allocs/op   │ allocs/op   vs base                  │
BuilderTestCases/metric_with_labels-10                      3.000 ± 0%     1.000 ± 0%  -66.67% (p=0.000 n=10)
BuilderTestCases/metric_with_single_label-10                2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.000 n=10)
BuilderTestCases/metric_without_label-10                    1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
BuilderTestCases/no_name-10                                 0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
BuilderTestCases/some_empty_labels_and_values-10            2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.000 n=10)
BuilderTestCases/values_contain_double_quotes-10            7.000 ± 0%     1.000 ± 0%  -85.71% (p=0.000 n=10)
BuilderTestCases/values_with_and_without_double_quotes-10   7.000 ± 0%     1.000 ± 0%  -85.71% (p=0.000 n=10)
geomean                                                                ²               -59.79%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```