### PR TITLE
add support for different label value types

### DIFF
--- a/vimebu.go
+++ b/vimebu.go
@@ -216,9 +216,3 @@ func (b *Builder) String() string {
 	b.underlying.WriteByte(rightBracketByte)
 	return b.underlying.String()
 }
-
-// Reset resets the Builder to be empty.
-func (b *Builder) Reset() {
-	b.flName, b.flLabel = false, false
-	putBuffer(b.underlying)
-}

--- a/vimebu_func_test.go
+++ b/vimebu_func_test.go
@@ -10,10 +10,15 @@ func handleTestCaseFunc(t *testing.T, tc testCase) {
 	labels := make([]LabelCallback, 0, len(tc.input.labels))
 
 	for _, label := range tc.input.labels {
-		if label.shouldQuote {
-			labels = append(labels, WithLabelQuote(label.name, label.value))
-		} else {
-			labels = append(labels, WithLabel(label.name, label.value))
+		switch v := label.value.(type) {
+		case string:
+			if label.shouldQuote {
+				labels = append(labels, WithLabelQuote(label.name, v))
+			} else {
+				labels = append(labels, WithLabel(label.name, v))
+			}
+		default: // If labels contain something else than a string, skip the test.
+			return
 		}
 	}
 
@@ -50,10 +55,15 @@ func BenchmarkBuilderFuncTestCases(b *testing.B) {
 			labels := make([]LabelCallback, 0, len(tc.input.labels))
 
 			for _, label := range tc.input.labels {
-				if label.shouldQuote {
-					labels = append(labels, WithLabelQuote(label.name, label.value))
-				} else {
-					labels = append(labels, WithLabel(label.name, label.value))
+				switch v := label.value.(type) {
+				case string:
+					if label.shouldQuote {
+						labels = append(labels, WithLabelQuote(label.name, v))
+					} else {
+						labels = append(labels, WithLabel(label.name, v))
+					}
+				default: // If labels contain something else than a string, skip the bench.
+					return
 				}
 			}
 

--- a/vimebu_test.go
+++ b/vimebu_test.go
@@ -207,12 +207,6 @@ func handleTestCase(t *testing.T, tc testCase) {
 
 	result := b.String()
 	require.Equal(t, tc.expected, result)
-
-	t.Run("reset", func(t *testing.T) {
-		b.Reset()
-		require.False(t, b.flName)
-		require.False(t, b.flLabel)
-	})
 }
 
 func TestBuilder(t *testing.T) {


### PR DESCRIPTION
With this PR, we can set a bool, float or int as a label value using the corresponding builder methods.

It either uses `strconv.Append...` functions or `append` under the hood to be as fast as possible and to make fewer allocations possible.

Running benchmarks gives a solid 1 alloc/op for each test case :)

## Example usage
```go
var builder vimebu.Builder
builder.Metric("your_metric_name")
builder.Label("host", 1.2.3.4) // String.
builder.LabelBool("with_retry", true) // Boolean.
builder.LabelInt("val", 1234) // Int.
builder.LabelFloat("p", 123.456) // Float.
_ = builder.String() // your_metric_name{host="1.2.3.4",with_retry="true",val="1234",p="123.456"}
```