### PR TITLE
stop manually adding brackets when metric has no label

### DIFF
--- a/vimebu.go
+++ b/vimebu.go
@@ -71,7 +71,6 @@ func (b *Builder) Metric(name string) *Builder {
 	b.init()
 
 	b.underlying.WriteString(name)
-	b.underlying.WriteByte(leftBracketByte)
 	b.flName = true
 
 	return b
@@ -181,6 +180,7 @@ func (b *Builder) label(name string, escapeQuote bool, stringValue *string, bool
 	if b.flLabel { // If we already wrote a label, start writing commas before label names.
 		b.underlying.WriteByte(commaByte)
 	} else { // Otherwise, mark flag as true for next pass.
+		b.underlying.WriteByte(leftBracketByte)
 		b.flLabel = true
 	}
 
@@ -248,7 +248,8 @@ func (b *Builder) String() string {
 	if !b.flName {
 		return ""
 	}
-
-	b.underlying.WriteByte(rightBracketByte)
+	if b.flLabel {
+		b.underlying.WriteByte(rightBracketByte)
+	}
 	return b.underlying.String()
 }

--- a/vimebu_test.go
+++ b/vimebu_test.go
@@ -55,7 +55,7 @@ var testCases = []testCase{
 		input: input{
 			name: "http_request_duration_seconds",
 		},
-		expected: `http_request_duration_seconds{}`,
+		expected: `http_request_duration_seconds`,
 	},
 	{
 		name:      "no name",
@@ -123,7 +123,7 @@ var testCases = []testCase{
 			name:   "api_http_requests_total",
 			labels: []label{{strings.Repeat("b", 256), "test", false}},
 		},
-		expected:  `api_http_requests_total{}`,
+		expected:  `api_http_requests_total`,
 		skipBench: true,
 	},
 	{
@@ -132,7 +132,7 @@ var testCases = []testCase{
 			name:   "api_http_requests_total",
 			labels: []label{{"test", strings.Repeat("b", 2048), false}},
 		},
-		expected:  `api_http_requests_total{}`,
+		expected:  `api_http_requests_total`,
 		skipBench: true,
 	},
 	{


### PR DESCRIPTION
Self explanatory. 

VM doesn't require brackets, and it actually creates a "bug" where a histogram with no label will get a prefixing comma on the `vmrange` label like so :
```
metric_name_bucket{,vmrange="2.154e+01...2.448e+01"}
```

Which causes querying problems on Grafana somehow 🤔 