### PR TITLE
add variants of the VictoriaMetrics builders

### DIFF
--- a/victoria_metrics.go
+++ b/victoria_metrics.go
@@ -11,7 +11,7 @@ func (b *Builder) GetOrCreateCounter() *metrics.Counter {
 	return metrics.GetOrCreateCounter(b.String())
 }
 
-// GetOrCreateCounterInSet calls [set.GetOrCreateCounter] using the Builder's accumulated string as argument.
+// GetOrCreateCounterInSet calls [metrics.Set.GetOrCreateCounter] using the Builder's accumulated string as argument.
 func (b *Builder) GetOrCreateCounterInSet(set *metrics.Set) *metrics.Counter {
 	return set.GetOrCreateCounter(b.String())
 }
@@ -21,7 +21,7 @@ func (b *Builder) NewCounter() *metrics.Counter {
 	return metrics.NewCounter(b.String())
 }
 
-// NewCounterInSet calls [set.NewCounter] using the Builder's accumulated string as argument.
+// NewCounterInSet calls [metrics.Set.NewCounter] using the Builder's accumulated string as argument.
 func (b *Builder) NewCounterInSet(set *metrics.Set) *metrics.Counter {
 	return set.NewCounter(b.String())
 }
@@ -31,7 +31,7 @@ func (b *Builder) GetOrCreateFloatCounter() *metrics.FloatCounter {
 	return metrics.GetOrCreateFloatCounter(b.String())
 }
 
-// GetOrCreateFloatCounterInSet calls [set.GetOrCreateFloatCounter] using the Builder's accumulated string as argument.
+// GetOrCreateFloatCounterInSet calls [metris.Set.GetOrCreateFloatCounter] using the Builder's accumulated string as argument.
 func (b *Builder) GetOrCreateFloatCounterInSet(set *metrics.Set) *metrics.FloatCounter {
 	return set.GetOrCreateFloatCounter(b.String())
 }
@@ -41,7 +41,7 @@ func (b *Builder) NewFloatCounter() *metrics.FloatCounter {
 	return metrics.NewFloatCounter(b.String())
 }
 
-// NewFloatCounterInSet calls [set.NewFloatCounter] using the Builder's accumulated string as argument.
+// NewFloatCounterInSet calls [metrics.Set.NewFloatCounter] using the Builder's accumulated string as argument.
 func (b *Builder) NewFloatCounterInSet(set *metrics.Set) *metrics.FloatCounter {
 	return set.NewFloatCounter(b.String())
 }
@@ -51,7 +51,7 @@ func (b *Builder) GetOrCreateHistogram() *metrics.Histogram {
 	return metrics.GetOrCreateHistogram(b.String())
 }
 
-// GetOrCreateHistogramInSet calls [set.GetOrCreateHistogram] using the Builder's accumulated string as argument.
+// GetOrCreateHistogramInSet calls [metrics.Set.GetOrCreateHistogram] using the Builder's accumulated string as argument.
 func (b *Builder) GetOrCreateHistogramInSet(set *metrics.Set) *metrics.Histogram {
 	return set.GetOrCreateHistogram(b.String())
 }
@@ -61,7 +61,7 @@ func (b *Builder) NewHistogram() *metrics.Histogram {
 	return metrics.NewHistogram(b.String())
 }
 
-// NewHistogramInSet calls [set.NewHistogram] using the Builder's accumulated string as argument.
+// NewHistogramInSet calls [metrics.Set.NewHistogram] using the Builder's accumulated string as argument.
 func (b *Builder) NewHistogramInSet(set *metrics.Set) *metrics.Histogram {
 	return set.NewHistogram(b.String())
 }
@@ -71,7 +71,7 @@ func (b *Builder) GetOrCreateGauge(f func() float64) *metrics.Gauge {
 	return metrics.GetOrCreateGauge(b.String(), f)
 }
 
-// GetOrCreateGaugeInSet calls [set.GetOrCreateGauge] using the Builder's accumulated string as argument.
+// GetOrCreateGaugeInSet calls [metrics.Set.GetOrCreateGauge] using the Builder's accumulated string as argument.
 func (b *Builder) GetOrCreateGaugeInSet(set *metrics.Set, f func() float64) *metrics.Gauge {
 	return set.GetOrCreateGauge(b.String(), f)
 }
@@ -81,7 +81,7 @@ func (b *Builder) NewGauge(f func() float64) *metrics.Gauge {
 	return metrics.NewGauge(b.String(), f)
 }
 
-// NewGaugeInSet calls [set.NewGauge] using the Builder's accumulated string as argument.
+// NewGaugeInSet calls [metrics.Set.NewGauge] using the Builder's accumulated string as argument.
 func (b *Builder) NewGaugeInSet(set *metrics.Set, f func() float64) *metrics.Gauge {
 	return set.NewGauge(b.String(), f)
 }
@@ -91,7 +91,7 @@ func (b *Builder) GetOrCreateSummary() *metrics.Summary {
 	return metrics.GetOrCreateSummary(b.String())
 }
 
-// GetOrCreateSummaryInSet calls [set.GetOrCreateSummary] using the Builder's accumulated string as argument.
+// GetOrCreateSummaryInSet calls [metrics.Set.GetOrCreateSummary] using the Builder's accumulated string as argument.
 func (b *Builder) GetOrCreateSummaryInSet(set *metrics.Set) *metrics.Summary {
 	return set.GetOrCreateSummary(b.String())
 }
@@ -101,7 +101,7 @@ func (b *Builder) NewSummary() *metrics.Summary {
 	return metrics.NewSummary(b.String())
 }
 
-// NewSummaryInSet calls [set.NewSummary] using the Builder's accumulated string as argument.
+// NewSummaryInSet calls [metrics.Set.NewSummary] using the Builder's accumulated string as argument.
 func (b *Builder) NewSummaryInSet(set *metrics.Set) *metrics.Summary {
 	return set.NewSummary(b.String())
 }
@@ -111,7 +111,7 @@ func (b *Builder) GetOrCreateSummaryExt(window time.Duration, quantiles []float6
 	return metrics.GetOrCreateSummaryExt(b.String(), window, quantiles)
 }
 
-// GetOrCreateSummaryExtInSet calls [set.GetOrCreateSummaryExt] using the Builder's accumulated string as argument.
+// GetOrCreateSummaryExtInSet calls [metrics.Set.GetOrCreateSummaryExt] using the Builder's accumulated string as argument.
 func (b *Builder) GetOrCreateSummaryExtInSet(set *metrics.Set, window time.Duration, quantiles []float64) *metrics.Summary {
 	return set.GetOrCreateSummaryExt(b.String(), window, quantiles)
 }
@@ -121,7 +121,7 @@ func (b *Builder) NewSummaryExt(window time.Duration, quantiles []float64) *metr
 	return metrics.NewSummaryExt(b.String(), window, quantiles)
 }
 
-// GetOrCreateHistogramInSet calls [metrics.GetOrCreateHistogram] using the Builder's accumulated string as argument.
+// NewSummaryExtInSet calls [metrics.Set.NewSummaryExtInSet] using the Builder's accumulated string as argument.
 func (b *Builder) NewSummaryExtInSet(set *metrics.Set, window time.Duration, quantiles []float64) *metrics.Summary {
 	return set.NewSummaryExt(b.String(), window, quantiles)
 }

--- a/victoria_metrics.go
+++ b/victoria_metrics.go
@@ -11,9 +11,19 @@ func (b *Builder) GetOrCreateCounter() *metrics.Counter {
 	return metrics.GetOrCreateCounter(b.String())
 }
 
+// GetOrCreateCounterInSet calls [set.GetOrCreateCounter] using the Builder's accumulated string as argument.
+func (b *Builder) GetOrCreateCounterInSet(set *metrics.Set) *metrics.Counter {
+	return set.GetOrCreateCounter(b.String())
+}
+
 // NewCounter calls [metrics.NewCounter] using the Builder's accumulated string as argument.
 func (b *Builder) NewCounter() *metrics.Counter {
 	return metrics.NewCounter(b.String())
+}
+
+// NewCounterInSet calls [set.NewCounter] using the Builder's accumulated string as argument.
+func (b *Builder) NewCounterInSet(set *metrics.Set) *metrics.Counter {
+	return set.NewCounter(b.String())
 }
 
 // GetOrCreateFloatCounter calls [metrics.GetOrCreateFloatCounter] using the Builder's accumulated string as argument.
@@ -21,9 +31,19 @@ func (b *Builder) GetOrCreateFloatCounter() *metrics.FloatCounter {
 	return metrics.GetOrCreateFloatCounter(b.String())
 }
 
+// GetOrCreateFloatCounterInSet calls [set.GetOrCreateFloatCounter] using the Builder's accumulated string as argument.
+func (b *Builder) GetOrCreateFloatCounterInSet(set *metrics.Set) *metrics.FloatCounter {
+	return set.GetOrCreateFloatCounter(b.String())
+}
+
 // NewFloatCounter calls [metrics.NewFloatCounter] using the Builder's accumulated string as argument.
 func (b *Builder) NewFloatCounter() *metrics.FloatCounter {
 	return metrics.NewFloatCounter(b.String())
+}
+
+// NewFloatCounterInSet calls [set.NewFloatCounter] using the Builder's accumulated string as argument.
+func (b *Builder) NewFloatCounterInSet(set *metrics.Set) *metrics.FloatCounter {
+	return set.NewFloatCounter(b.String())
 }
 
 // GetOrCreateHistogram calls [metrics.GetOrCreateHistogram] using the Builder's accumulated string as argument.
@@ -31,9 +51,19 @@ func (b *Builder) GetOrCreateHistogram() *metrics.Histogram {
 	return metrics.GetOrCreateHistogram(b.String())
 }
 
+// GetOrCreateHistogramInSet calls [set.GetOrCreateHistogram] using the Builder's accumulated string as argument.
+func (b *Builder) GetOrCreateHistogramInSet(set *metrics.Set) *metrics.Histogram {
+	return set.GetOrCreateHistogram(b.String())
+}
+
 // NewHistogram calls [metrics.NewHistogram] using the Builder's accumulated string as argument.
 func (b *Builder) NewHistogram() *metrics.Histogram {
 	return metrics.NewHistogram(b.String())
+}
+
+// NewHistogramInSet calls [set.NewHistogram] using the Builder's accumulated string as argument.
+func (b *Builder) NewHistogramInSet(set *metrics.Set) *metrics.Histogram {
+	return set.NewHistogram(b.String())
 }
 
 // GetOrCreateGauge calls [metrics.GetOrCreateGauge] using the Builder's accumulated string as argument.
@@ -41,9 +71,19 @@ func (b *Builder) GetOrCreateGauge(f func() float64) *metrics.Gauge {
 	return metrics.GetOrCreateGauge(b.String(), f)
 }
 
+// GetOrCreateGaugeInSet calls [set.GetOrCreateGauge] using the Builder's accumulated string as argument.
+func (b *Builder) GetOrCreateGaugeInSet(set *metrics.Set, f func() float64) *metrics.Gauge {
+	return set.GetOrCreateGauge(b.String(), f)
+}
+
 // NewGauge calls [metrics.NewGauge] using the Builder's accumulated string as argument.
 func (b *Builder) NewGauge(f func() float64) *metrics.Gauge {
 	return metrics.NewGauge(b.String(), f)
+}
+
+// NewGaugeInSet calls [set.NewGauge] using the Builder's accumulated string as argument.
+func (b *Builder) NewGaugeInSet(set *metrics.Set, f func() float64) *metrics.Gauge {
+	return set.NewGauge(b.String(), f)
 }
 
 // GetOrCreateSummary calls [metrics.GetOrCreateSummary] using the Builder's accumulated string as argument.
@@ -51,9 +91,19 @@ func (b *Builder) GetOrCreateSummary() *metrics.Summary {
 	return metrics.GetOrCreateSummary(b.String())
 }
 
+// GetOrCreateSummaryInSet calls [set.GetOrCreateSummary] using the Builder's accumulated string as argument.
+func (b *Builder) GetOrCreateSummaryInSet(set *metrics.Set) *metrics.Summary {
+	return set.GetOrCreateSummary(b.String())
+}
+
 // NewSummary calls [metrics.NewSummary] using the Builder's accumulated string as argument.
 func (b *Builder) NewSummary() *metrics.Summary {
 	return metrics.NewSummary(b.String())
+}
+
+// NewSummaryInSet calls [set.NewSummary] using the Builder's accumulated string as argument.
+func (b *Builder) NewSummaryInSet(set *metrics.Set) *metrics.Summary {
+	return set.NewSummary(b.String())
 }
 
 // GetOrCreateSummaryExt calls [metrics.GetOrCreateSummaryExt] using the Builder's accumulated string as argument.
@@ -61,7 +111,17 @@ func (b *Builder) GetOrCreateSummaryExt(window time.Duration, quantiles []float6
 	return metrics.GetOrCreateSummaryExt(b.String(), window, quantiles)
 }
 
+// GetOrCreateSummaryExtInSet calls [set.GetOrCreateSummaryExt] using the Builder's accumulated string as argument.
+func (b *Builder) GetOrCreateSummaryExtInSet(set *metrics.Set, window time.Duration, quantiles []float64) *metrics.Summary {
+	return set.GetOrCreateSummaryExt(b.String(), window, quantiles)
+}
+
 // GetOrCreateHistogram calls [metrics.GetOrCreateHistogram] using the Builder's accumulated string as argument.
 func (b *Builder) NewSummaryExt(window time.Duration, quantiles []float64) *metrics.Summary {
 	return metrics.NewSummaryExt(b.String(), window, quantiles)
+}
+
+// GetOrCreateHistogramInSet calls [metrics.GetOrCreateHistogram] using the Builder's accumulated string as argument.
+func (b *Builder) NewSummaryExtInSet(set *metrics.Set, window time.Duration, quantiles []float64) *metrics.Summary {
+	return set.NewSummaryExt(b.String(), window, quantiles)
 }


### PR DESCRIPTION
In some cases we need to create a metric in a specific [metrics.Set](https://pkg.go.dev/github.com/VictoriaMetrics/metrics#Set), for example if you want to unregister a bunch of metrics at some point the easiest way to do that is to use a dedicated set and use [metrics.UnregisterSet](https://pkg.go.dev/github.com/VictoriaMetrics/metrics#UnregisterSet).

This PR adds variants of the VM helpers that allow creating the metric in a specific set instead of the global set.