### PR TITLE
refactor: use unsafe to avoid alloc

### DIFF
--- a/vimebu.go
+++ b/vimebu.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"unsafe"
 )
 
 const (
@@ -251,5 +252,13 @@ func (b *Builder) String() string {
 	if b.flLabel {
 		b.underlying.WriteByte(rightBracketByte)
 	}
-	return b.underlying.String()
+
+	return b.unsafeString()
+}
+
+// unsafeString returns the accumulated string using
+// [strings.Builder]'s unsafe code to reduce allocations.
+func (b *Builder) unsafeString() string {
+	buf := b.underlying
+	return unsafe.String(unsafe.SliceData(buf.Bytes()), buf.Len())
 }


### PR DESCRIPTION
Benchmark results :
```
❯ benchstat safe unsafe
goos: darwin
goarch: arm64
pkg: github.com/wazazaby/vimebu
                                                          │     safe     │               unsafe                │
                                                          │    sec/op    │   sec/op     vs base                │
BuilderTestCases/metric_with_labels-10                       66.78n ± 1%   50.46n ± 1%  -24.44% (p=0.000 n=15)
BuilderTestCases/metric_with_single_label-10                 49.13n ± 2%   35.79n ± 0%  -27.15% (p=0.000 n=15)
BuilderTestCases/metric_without_label-10                     31.53n ± 2%   18.96n ± 1%  -39.87% (p=0.000 n=15)
BuilderTestCases/metric_with_a_lot_of_labels-10              208.8n ± 1%   185.4n ± 1%  -11.21% (p=0.000 n=15)
BuilderTestCases/values_contain_double_quotes-10             471.2n ± 2%   459.3n ± 1%   -2.53% (p=0.000 n=15)
BuilderTestCases/values_with_and_without_double_quotes-10    507.1n ± 1%   489.3n ± 1%   -3.51% (p=0.000 n=15)
BuilderTestCases/mixed_label_value_types-10                  271.8n ± 1%   248.3n ± 1%   -8.65% (p=0.000 n=15)
BuilderTestCases/bool_label_values-10                        61.98n ± 1%   47.25n ± 1%  -23.77% (p=0.000 n=15)
BuilderTestCases/int64_label_values-10                      108.50n ± 4%   91.86n ± 1%  -15.34% (p=0.000 n=15)
BuilderTestCases/float64_label_values-10                     310.7n ± 1%   301.0n ± 1%   -3.12% (p=0.000 n=15)
BuilderTestCases/fmt.Stringer_label_values-10               106.80n ± 2%   91.84n ± 1%  -14.01% (p=0.000 n=15)
geomean                                                      136.8n        114.1n       -16.60%

                                                          │    safe    │                 unsafe                 │
                                                          │    B/op    │   B/op     vs base                     │
BuilderTestCases/metric_with_labels-10                      64.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/metric_with_single_label-10                32.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/metric_without_label-10                    32.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/metric_with_a_lot_of_labels-10             176.0 ± 0%    0.0 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/values_contain_double_quotes-10            112.0 ± 0%    0.0 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/values_with_and_without_double_quotes-10   160.0 ± 0%    0.0 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/mixed_label_value_types-10                 128.0 ± 0%    0.0 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/bool_label_values-10                       64.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/int64_label_values-10                      64.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/float64_label_values-10                    96.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/fmt.Stringer_label_values-10               64.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=15)
geomean                                                     78.17                   ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                                                          │    safe    │                 unsafe                  │
                                                          │ allocs/op  │ allocs/op   vs base                     │
BuilderTestCases/metric_with_labels-10                      1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/metric_with_single_label-10                1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/metric_without_label-10                    1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/metric_with_a_lot_of_labels-10             1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/values_contain_double_quotes-10            1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/values_with_and_without_double_quotes-10   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/mixed_label_value_types-10                 1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/bool_label_values-10                       1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/int64_label_values-10                      1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/float64_label_values-10                    1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=15)
BuilderTestCases/fmt.Stringer_label_values-10               1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=15)
geomean                                                     1.000                    ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```