### PR TITLE
feat: more logs when the input data is wrong somehow

### DIFF
--- a/vimebu.go
+++ b/vimebu.go
@@ -156,11 +156,11 @@ func (b *Builder) label(name string, escapeQuote bool, stringValue *string, bool
 
 	ln := len(name)
 	if ln == 0 {
-		log.Println("label name must not be empty, skipping")
+		log.Printf("metric: %q, label name must not be empty, skipping", b.underlying)
 		return b
 	}
 	if ln > LabelNameMaxLen {
-		log.Println("label name contains too many bytes, skipping")
+		log.Printf("metric: %q, label name: %q, label name contains too many bytes, skipping", b.underlying, name)
 		return b
 	}
 
@@ -168,11 +168,11 @@ func (b *Builder) label(name string, escapeQuote bool, stringValue *string, bool
 	if stringValue != nil {
 		lv := len(*stringValue)
 		if lv == 0 {
-			log.Println("label value must not be empty, skipping")
+			log.Printf("metric: %q, label name: %q, label value must not be empty, skipping", b.underlying, name)
 			return b
 		}
 		if lv > LabelValueLen {
-			log.Println("label value contains too many bytes, skipping")
+			log.Printf("metric: %q, label name: %q, label value contains too many bytes, skipping", b.underlying, name)
 			return b
 		}
 	}


### PR DESCRIPTION
This PR improves the logs to help track down where a label might be wrong.

Before:
```
2024-01-29T16:14:59.659+0100	INFO	vimebu@v1.1.0/vimebu.go:171	label value must not be empty, skipping
2024-01-29T16:14:59.659+0100	INFO	vimebu@v1.1.0/vimebu.go:171	label value must not be empty, skipping
2024-01-29T16:14:59.660+0100	INFO	vimebu@v1.1.0/vimebu.go:171	label value must not be empty, skipping
2024-01-29T16:14:59.660+0100	INFO	vimebu@v1.1.0/vimebu.go:171	label value must not be empty, skipping
2024-01-29T16:14:59.660+0100	INFO	vimebu@v1.1.0/vimebu.go:171	label value must not be empty, skipping
2024-01-29T16:14:59.660+0100	INFO	vimebu@v1.1.0/vimebu.go:171	label value must not be empty, skipping
```

After:
```
2024-01-29T16:13:10.496+0100	INFO	vimebu/vimebu.go:171	metric: "kafka_broker_connect", label name: "host", label value must not be empty, skipping
2024-01-29T16:13:10.497+0100	INFO	vimebu/vimebu.go:171	metric: "kafka_broker_write_wait", label name: "host", label value must not be empty, skipping
2024-01-29T16:13:10.497+0100	INFO	vimebu/vimebu.go:171	metric: "kafka_broker_bytes_written", label name: "host", label value must not be empty, skipping
2024-01-29T16:13:10.497+0100	INFO	vimebu/vimebu.go:171	metric: "kafka_broker_write_latencies", label name: "host", label value must not be empty, skipping
```