### PR TITLE
refactor: use own buffer instead of bytes.Buffer

### DIFF
--- a/buffer_pool.go
+++ b/buffer_pool.go
@@ -1,27 +1,32 @@
 package vimebu
 
 import (
-	"bytes"
 	"sync"
 )
+
+type buffer struct {
+	buf []byte
+}
 
 // bytesBufferPool is a simple pool to create or retrieve a [bytes.Buffer].
 var bytesBufferPool = sync.Pool{
 	New: func() any {
-		return new(bytes.Buffer)
+		return &buffer{
+			buf: make([]byte, 0, 64),
+		}
 	},
 }
 
 // getBuffer acquires a [bytes.Buffer] from the pool.
-func getBuffer() *bytes.Buffer {
-	return bytesBufferPool.Get().(*bytes.Buffer)
+func getBuffer() *buffer {
+	return bytesBufferPool.Get().(*buffer)
 }
 
 // putBuffer resets and returns a [bytes.Buffer] to the pool.
-func putBuffer(b *bytes.Buffer) {
+func putBuffer(b *buffer) {
 	if b == nil {
 		return
 	}
-	b.Reset()
+	b.buf = b.buf[:0]
 	bytesBufferPool.Put(b)
 }

--- a/vimebu.go
+++ b/vimebu.go
@@ -13,11 +13,11 @@ var (
 )
 
 const (
-	leftBracketByte  = byte('{')
-	rightBracketByte = byte('}')
-	commaByte        = byte(',')
-	equalByte        = byte('=')
-	doubleQuotesByte = byte('"')
+	leftBracketByte  byte = '{'
+	rightBracketByte byte = '}'
+	commaByte        byte = ','
+	equalByte        byte = '='
+	doubleQuotesByte byte = '"'
 )
 
 // Builder is used to efficiently build a VictoriaMetrics metric.


### PR DESCRIPTION
Big improvement
```
goos: darwin
goarch: arm64
pkg: github.com/wazazaby/vimebu
                                                          │  bytesbuffer  │              ownbuffer              │
                                                          │    sec/op     │    sec/op     vs base               │
BuilderTestCases/metric_with_labels-10                       48.72n ± ∞ ¹   40.83n ± ∞ ¹  -16.19% (p=0.008 n=5)
BuilderTestCases/metric_with_single_label-10                 35.67n ± ∞ ¹   29.10n ± ∞ ¹  -18.42% (p=0.008 n=5)
BuilderTestCases/metric_without_label-10                     18.50n ± ∞ ¹   17.72n ± ∞ ¹   -4.22% (p=0.008 n=5)
BuilderTestCases/metric_with_a_lot_of_labels-10              186.0n ± ∞ ¹   128.3n ± ∞ ¹  -31.02% (p=0.008 n=5)
BuilderTestCases/values_contain_double_quotes-10             340.6n ± ∞ ¹   325.2n ± ∞ ¹   -4.52% (p=0.008 n=5)
BuilderTestCases/values_with_and_without_double_quotes-10    371.1n ± ∞ ¹   347.1n ± ∞ ¹   -6.47% (p=0.008 n=5)
BuilderTestCases/mixed_label_value_types-10                  254.1n ± ∞ ¹   224.2n ± ∞ ¹  -11.77% (p=0.008 n=5)
BuilderTestCases/bool_label_values-10                        46.06n ± ∞ ¹   36.27n ± ∞ ¹  -21.25% (p=0.008 n=5)
BuilderTestCases/int_label_values-10                         125.0n ± ∞ ¹   102.5n ± ∞ ¹  -18.00% (p=0.008 n=5)
BuilderTestCases/uint_label_values-10                       122.40n ± ∞ ¹   98.48n ± ∞ ¹  -19.54% (p=0.008 n=5)
BuilderTestCases/float_label_values-10                       297.2n ± ∞ ¹   271.9n ± ∞ ¹   -8.51% (p=0.008 n=5)
BuilderTestCases/fmt.Stringer_label_values-10                76.41n ± ∞ ¹   63.85n ± ∞ ¹  -16.44% (p=0.008 n=5)
geomean                                                      109.8n         93.29n        -15.04%
¹ need >= 6 samples for confidence interval at level 0.95

                                                          │ bytesbuffer │              ownbuffer              │
                                                          │    B/op     │    B/op      vs base                │
BuilderTestCases/metric_with_labels-10                      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/metric_with_single_label-10                0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/metric_without_label-10                    0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/metric_with_a_lot_of_labels-10             0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/values_contain_double_quotes-10            0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/values_with_and_without_double_quotes-10   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/mixed_label_value_types-10                 0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/bool_label_values-10                       0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/int_label_values-10                        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/uint_label_values-10                       0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/float_label_values-10                      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/fmt.Stringer_label_values-10               0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
geomean                                                               ³                +0.00%               ³
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ summaries must be >0 to compute geomean

                                                          │ bytesbuffer │              ownbuffer              │
                                                          │  allocs/op  │  allocs/op   vs base                │
BuilderTestCases/metric_with_labels-10                      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/metric_with_single_label-10                0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/metric_without_label-10                    0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/metric_with_a_lot_of_labels-10             0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/values_contain_double_quotes-10            0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/values_with_and_without_double_quotes-10   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/mixed_label_value_types-10                 0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/bool_label_values-10                       0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/int_label_values-10                        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/uint_label_values-10                       0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/float_label_values-10                      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
BuilderTestCases/fmt.Stringer_label_values-10               0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
geomean                                                               ³                +0.00%               ³
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ summaries must be >0 to compute geomean
```